### PR TITLE
signupLoginLogout11

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -12,7 +12,6 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
     resource "*",
       headers: :any,
       methods: [:get, :post, :put, :patch, :delete, :options, :head],
-      expose: ['Access-Control-Allow-Origin'],
       credentials: true # セッション管理のためにcredentialsをtrueに設定
   end
 end


### PR DESCRIPTION
- [ ]curlリクエスト通らなくなっていたので、cors.rbのexpose: ['Access-Control-Allow-Origin']を削除