### PR TITLE
not_skip_verify_authenticity_token5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,6 @@ COPY entrypoint.sh /usr/bin/
 RUN chmod +x /usr/bin/entrypoint.sh
 ENTRYPOINT ["entrypoint.sh"]
 
-EXPOSE 3002
+EXPOSE 3000
 
 CMD ["rails", "server", "-b", "0.0.0.0"]


### PR DESCRIPTION
- [ ] ```nrt [error][PC01] instance refused connection. is your app listening on 0.0.0.0:3000? ```対応のために、Dockerfile の ```EXPOSE``` を ```3000``` に変更