### PR TITLE
Feature/issue146

### DIFF
--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -33,10 +33,12 @@ class PetsController < ApplicationController
           end
 
     if pet
+      species = current_user.dog.present? ? '犬' : '猫'
       render json: {
         id: pet.id,
         name: pet.name,
         breed: pet.breed,
+        species: species,  # 犬か猫か
         level: pet.level,
         experience: pet.experience,
         physical:pet.physical,

--- a/db/migrate/20240924102632_update_breed.rb
+++ b/db/migrate/20240924102632_update_breed.rb
@@ -1,0 +1,13 @@
+class UpdateBreed < ActiveRecord::Migration[7.0]
+  def up
+    # タイプ1をダックスフンドに変更
+    Dog.where(breed: 'タイプ1').update_all(breed: 'ダックスフンド')
+    Cat.where(breed: 'タイプ1').update_all(breed: '三毛猫')
+  end
+
+  def down
+    # 変更を元に戻す場合
+    Dog.where(breed: 'ダックスフンド').update_all(breed: 'タイプ1')
+    Dog.where(breed: '三毛猫').update_all(breed: 'タイプ1')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_09_13_115156) do
+ActiveRecord::Schema[7.0].define(version: 2024_09_24_102632) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
- [ ] 既にペット作成されている場合、カスタマイズに情報を入力するために`pet_details`が犬か猫を返すように設定
- [ ] `breed`を仮にタイプ1としていたのを、ダックスフンド、三毛猫とするためのマイグレーションファイルを作成