### PR TITLE
feat:バッドステータスになった日の制限追加

### DIFF
--- a/app/controllers/cats_controller.rb
+++ b/app/controllers/cats_controller.rb
@@ -55,10 +55,27 @@ class CatsController < ApplicationController
       return
     end
 
+    # 日をまたいだらフラグとプレイカウントをリセット
+    if @cat.last_played_at.present? && @cat.last_played_at.to_date != Date.current
+      @cat.bad_status_flag = false
+      @cat.play_count = 0
+    end
+
+    if @cat.bad_status_flag
+      if @cat.play_count >= 3
+        render json: { error: '今日はもう十分遊びました。また明日遊びましょう。' }, status: :unprocessable_entity
+        return
+      end
+    end
+
     previous_level = @cat.level
     @cat.gain_experience(15)
     @cat.physical -= 3
     @cat.physical = [@cat.physical, 0].max
+
+    # 遊び回数のカウントと最終遊び日時の更新
+    @dog.play_count += 1
+    @dog.last_played_at = Time.current
 
     # レベルアップと繁殖のフラグを設定
     level_up = @cat.level > previous_level

--- a/app/models/cat.rb
+++ b/app/models/cat.rb
@@ -37,6 +37,7 @@ class Cat < ApplicationRecord
     # 空腹状態をチェック (満腹度が20以下なら空腹フラグ)
     if self.satiety <= 20
       self.states |= 1  # 空腹フラグを立てる
+      self.bad_status_flag = true
     else
       self.states &= ~1 # 空腹フラグを解除
     end
@@ -44,6 +45,7 @@ class Cat < ApplicationRecord
     # 不機嫌状態をチェック (幸福度が20以下なら不機嫌フラグ)
     if self.happiness <= 20
       self.states |= 2  # 不機嫌フラグを立てる
+      self.bad_status_flag = true
     else
       self.states &= ~2 # 不機嫌フラグを解除
     end

--- a/app/models/dog.rb
+++ b/app/models/dog.rb
@@ -37,6 +37,7 @@ class Dog < ApplicationRecord
     # 空腹状態をチェック (満腹度が20以下なら空腹フラグ)
     if self.satiety <= 20
       self.states |= 1  # 空腹フラグを立てる
+      self.bad_status_flag = true
     else
       self.states &= ~1 # 空腹フラグを解除
     end
@@ -44,6 +45,7 @@ class Dog < ApplicationRecord
     # 不機嫌状態をチェック (幸福度が20以下なら不機嫌フラグ)
     if self.happiness <= 20
       self.states |= 2  # 不機嫌フラグを立てる
+      self.bad_status_flag = true
     else
       self.states &= ~2 # 不機嫌フラグを解除
     end

--- a/db/migrate/20240926120138_add_play_count_and_last_played_at_to_dogs_and_cats.rb
+++ b/db/migrate/20240926120138_add_play_count_and_last_played_at_to_dogs_and_cats.rb
@@ -1,0 +1,8 @@
+class AddPlayCountAndLastPlayedAtToDogsAndCats < ActiveRecord::Migration[7.0]
+  def change
+    add_column :dogs, :play_count, :integer, default: 0, null: false
+    add_column :dogs, :last_played_at, :datetime
+    add_column :cats, :play_count, :integer, default: 0, null: false
+    add_column :cats, :last_played_at, :datetime
+  end
+end

--- a/db/migrate/20240926122158_add_bad_ftatus_flag_at_to_dogs_and_cats.rb
+++ b/db/migrate/20240926122158_add_bad_ftatus_flag_at_to_dogs_and_cats.rb
@@ -1,0 +1,6 @@
+class AddBadFtatusFlagAtToDogsAndCats < ActiveRecord::Migration[7.0]
+  def change
+    add_column :dogs, :bad_status_flag, :boolean, default: false, null: false
+    add_column :cats, :bad_status_flag, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_09_24_102632) do
+ActiveRecord::Schema[7.0].define(version: 2024_09_26_122158) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -33,6 +33,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_24_102632) do
     t.integer "max_happiness", default: 100
     t.datetime "last_feed_at"
     t.datetime "last_stroke_at"
+    t.integer "play_count", default: 0, null: false
+    t.datetime "last_played_at"
+    t.boolean "bad_status_flag", default: false, null: false
     t.index ["user_id"], name: "index_cats_on_user_id"
   end
 
@@ -55,6 +58,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_24_102632) do
     t.integer "max_happiness", default: 100
     t.datetime "last_feed_at"
     t.datetime "last_stroke_at"
+    t.integer "play_count", default: 0, null: false
+    t.datetime "last_played_at"
+    t.boolean "bad_status_flag", default: false, null: false
     t.index ["user_id"], name: "index_dogs_on_user_id"
   end
 


### PR DESCRIPTION
- [ ] カラムに`play_count`、`last_played_at`、`bad_status_flag`を追加
- [ ] `update_states`でバッドステータスになった際に`bad_status_flag`を`true`にするように設定
- [ ] `bad_status_flag`が`true`の場合は遊ぶコマンドに制限をかけ、日をまたいだらフラグを解除するように設定