### PR TITLE
Feature/issue160

### DIFF
--- a/app/controllers/cats_controller.rb
+++ b/app/controllers/cats_controller.rb
@@ -69,6 +69,7 @@ class CatsController < ApplicationController
     end
 
     previous_level = @cat.level
+    previous_offspring_born = @cat.offspring_count
     @cat.gain_experience(15)
     @cat.physical -= 3
     @cat.physical = [@cat.physical, 0].max
@@ -79,7 +80,7 @@ class CatsController < ApplicationController
 
     # レベルアップと繁殖のフラグを設定
     level_up = @cat.level > previous_level
-    offspring_born = @cat.offspring_count > 0 && @cat.level % 3 == 0
+    offspring_born = @cat.offspring_count > previous_offspring_born
 
     if @cat.save
       render json: { cat: @cat, level_up: level_up, offspring_born: offspring_born, success: true }

--- a/app/controllers/dogs_controller.rb
+++ b/app/controllers/dogs_controller.rb
@@ -69,6 +69,7 @@ class DogsController < ApplicationController
     end
 
     previous_level = @dog.level
+    previous_offspring_born = @dog.offspring_count
     @dog.gain_experience(15)
     @dog.physical -= 3
     @dog.physical = [@dog.physical, 0].max
@@ -79,7 +80,7 @@ class DogsController < ApplicationController
 
     # レベルアップと繁殖のフラグを設定
     level_up = @dog.level > previous_level
-    offspring_born = @dog.offspring_count > 0 && @dog.level % 3 == 0
+    offspring_born = @dog.offspring_count > previous_offspring_born
 
     if @dog.save
       render json: { dog: @dog, level_up: level_up, offspring_born: offspring_born, success: true }

--- a/app/models/cat.rb
+++ b/app/models/cat.rb
@@ -19,10 +19,14 @@ class Cat < ApplicationRecord
       self.level += 1
     end
   
-    # レベル3に初めて達したときにのみ breeding を実行
-    if self.level % 3 == 0 && previous_level < self.level && !self.bred_at_level_3
+    # レベルが3の倍数に到達した場合、繁殖フラグをリセット
+    if self.level % 3 != 0
+      self.bred_at_level_3 = false
+    end
+  
+    # レベル3の倍数に初めて達したときのみ繁殖を実行
+    if self.level % 3 == 0 && !self.bred_at_level_3
       breeding
-      self.bred_at_level_3 = true
     end
   
     save
@@ -30,6 +34,7 @@ class Cat < ApplicationRecord
 
   def breeding
     self.offspring_count += 1 # 繁殖回数を増やす
+    self.bred_at_level_3 = true # フラグをここで設定
     save
   end
 

--- a/app/models/dog.rb
+++ b/app/models/dog.rb
@@ -12,17 +12,21 @@ class Dog < ApplicationRecord
   def gain_experience(amount)
     self.experience += amount
     previous_level = self.level
-  
+    
     # レベルアップの条件を確認し、必要に応じてレベルを上げる
     if self.experience >= level_up_experience
       self.experience -= level_up_experience
       self.level += 1
     end
   
-    # レベル3に初めて達したときにのみ breeding を実行
-    if self.level % 3 == 0 && previous_level < self.level && !self.bred_at_level_3
+    # レベルが3の倍数に到達した場合、繁殖フラグをリセット
+    if self.level % 3 != 0
+      self.bred_at_level_3 = false
+    end
+  
+    # レベル3の倍数に初めて達したときのみ繁殖を実行
+    if self.level % 3 == 0 && !self.bred_at_level_3
       breeding
-      self.bred_at_level_3 = true
     end
   
     save
@@ -30,6 +34,7 @@ class Dog < ApplicationRecord
 
   def breeding
     self.offspring_count += 1 # 繁殖回数を増やす
+    self.bred_at_level_3 = true # フラグをここで設定
     save
   end
 


### PR DESCRIPTION
- [ ] `level_up`と同様に経験値取得前の数値と比較することで、繁殖レベル時に何度も子供が生まれるメッセージが表示される不具合を修正